### PR TITLE
Switch renewable column descriptions

### DIFF
--- a/owid-energy-codebook.csv
+++ b/owid-energy-codebook.csv
@@ -101,13 +101,13 @@ other_renewables_energy_per_capita,"Per capita primary energy consumption from o
 per_capita_electricity,"Electricity consumption per capita, measured in kilowatt-hours",Calculated by Our World in Data based on BP Statistical Review of World Energy; Ember; and UN Population Estimates
 population,Total population,Gapminder and UN Population estimates
 primary_energy_consumption,"Primary energy consumption, measured in terawatt-hours",Calculated by Our World in Data based on BP Statistical Review of World Energy
-renewables_elec_per_capita,"Per capita primary energy consumption from renewables, measured in kilowatt-hours",Calculated by Our World in Data based on BP Statistical Review of World Energy; Gapminder and UN Population Estimates
+renewables_elec_per_capita,"Per capita electricity consumption from renewables, measured in kilowatt-hours",Calculated by Our World in Data based on BP Statistical Review of World Energy; Gapminder and UN Population Estimates
 renewables_share_elec,Share of electricity consumption that comes from renewables,Calculated by Our World in Data based on BP Statistical Review of World Energy and Ember
 renewables_cons_change_pct,Annual percentage change in renewable energy consumption,Calculated by Our World in Data based on BP Statistical Review of World Energy
 renewables_share_energy,Share of primary energy consumption that comes from renewables,Calculated by Our World in Data based on BP Statistical Review of World Energy
 renewables_cons_change_twh,"Annual change in renewable energy consumption, measured in terawatt-hours",Calculated by Our World in Data based on BP Statistical Review of World Energy
 renewables_consumption,"Primary energy consumption from renewables, measured in terawatt-hours",Calculated by Our World in Data based on BP Statistical Review of World Energy
-renewables_energy_per_capita,"Per capita electricity consumption from renewables, measured in kilowatt-hours",Calculated by Our World in Data based on BP Statistical Review of World Energy; Ember; and UN Population Estimates
+renewables_energy_per_capita,"Per capita primary energy consumption from renewables, measured in kilowatt-hours",Calculated by Our World in Data based on BP Statistical Review of World Energy; Ember; and UN Population Estimates
 solar_share_elec,Share of electricity consumption that comes from solar,Calculated by Our World in Data based on BP Statistical Review of World Energy and Ember
 solar_cons_change_pct,Annual percentage change in solar consumption,Calculated by Our World in Data based on BP Statistical Review of World Energy
 solar_share_energy,Share of primary energy consumption that comes from solar,Calculated by Our World in Data based on BP Statistical Review of World Energy


### PR DESCRIPTION
The column descriptions for `renewables_elec_per_capita` and `renewables_energy_per_capita` seem to be switched (electricity consumption vs primary energy consumption). The commit in this pull request switches the two descriptions (which is also consistent with the naming scheme other `**_elec_**` and `**_energy_**` columns in the dataset).