### PR TITLE
Fix missing coal electricity data for Switzerland, that should be zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Additionally, to construct region aggregates and indicators per capita and per G
 
 ## Changelog
 
+- On August 30, 2024:
+  - Fixed coal electricity generation for Switzerland, which was missing in the original data, and should be zero instead.
 - On June 20, 2024:
   - Updated the Energy Institute Statistical Review of World Energy.
   - Fixed issues on electricity data for aggregate regions.


### PR DESCRIPTION
Ember's Yearly Electricity Review does not have data for Switzerland's coal electricity production. But instead of missing, it should be zero (at least since 2000, where the data starts). I've set those nans to zero.
